### PR TITLE
Change ServiceChecker to an interface

### DIFF
--- a/src/main/kotlin/io/kungfury/coworker/CoworkerManager.kt
+++ b/src/main/kotlin/io/kungfury/coworker/CoworkerManager.kt
@@ -1,6 +1,5 @@
 package io.kungfury.coworker
 
-import io.kungfury.coworker.consul.ServiceChecker
 import io.kungfury.coworker.dbs.ConnectionManager
 import io.kungfury.coworker.dbs.ConnectionType
 import io.kungfury.coworker.dbs.Marginalia.AddMarginalia

--- a/src/main/kotlin/io/kungfury/coworker/ServiceChecker.kt
+++ b/src/main/kotlin/io/kungfury/coworker/ServiceChecker.kt
@@ -1,0 +1,11 @@
+package io.kungfury.coworker
+
+import kotlinx.coroutines.Deferred
+
+interface ServiceChecker {
+    fun getHostList(): ArrayList<String>
+
+    fun getServiceName(): String
+
+    fun getNewOfflineNodes(): Deferred<List<String>>
+}

--- a/src/main/kotlin/io/kungfury/coworker/consul/ConsulServiceChecker.kt
+++ b/src/main/kotlin/io/kungfury/coworker/consul/ConsulServiceChecker.kt
@@ -2,6 +2,7 @@ package io.kungfury.coworker.consul
 
 import com.jsoniter.JsonIterator
 import com.jsoniter.spi.JsonException
+import io.kungfury.coworker.ServiceChecker
 
 import kotlinx.coroutines.*
 
@@ -22,8 +23,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * Implements a service checker for consul.
  */
-class ServiceChecker(consulUri: String, service: String, consulToken: Optional<String>, timeout: Long?) {
-    private val LOGGER = LoggerFactory.getLogger(ServiceChecker::class.java)
+class ConsulServiceChecker(consulUri: String, service: String, consulToken: Optional<String>, timeout: Long?) : ServiceChecker {
+    private val LOGGER = LoggerFactory.getLogger(ConsulServiceChecker::class.java)
 
     private val consulService = service
     private val consulHost: String = "$consulUri/catalog/service/$consulService"
@@ -39,17 +40,17 @@ class ServiceChecker(consulUri: String, service: String, consulToken: Optional<S
     /**
      * Grab the host list of the Service Checker.
      */
-    fun getHostList(): ArrayList<String> = hostList
+    override fun getHostList(): ArrayList<String> = hostList
 
     /**
      * Get the name of the service
      */
-    fun getServiceName(): String = consulService
+    override fun getServiceName(): String = consulService
 
     /**
      * Get a list of the new offline nodes.
      */
-    fun getNewOfflineNodes(): Deferred<List<String>> {
+    override fun getNewOfflineNodes(): Deferred<List<String>> {
         return GlobalScope.async {
             withTimeout(consulTimeoutMs) {
                 CoroutineName("getNewOfflineNodes - $consulService")

--- a/src/test/kotlin/io/kungfury/coworker/consul/ConsulServiceCheckerSpec.kt
+++ b/src/test/kotlin/io/kungfury/coworker/consul/ConsulServiceCheckerSpec.kt
@@ -17,7 +17,7 @@ import java.io.IOException
 import java.util.Optional
 import java.util.concurrent.TimeUnit
 
-class ServiceCheckerSpec : FunSpec({
+class ConsulServiceCheckerSpec : FunSpec({
     val dispatcher: Dispatcher = object : Dispatcher() {
         @Throws(InterruptedException::class)
         override fun dispatch(request: RecordedRequest): MockResponse {
@@ -41,7 +41,7 @@ class ServiceCheckerSpec : FunSpec({
 
     test("getNewOfflineNodes can parse a full service") {
         val url = server.url("/v1").toUri().toASCIIString()
-        val serviceChecker = ServiceChecker(url, "foobar", Optional.empty(), null)
+        val serviceChecker = ConsulServiceChecker(url, "foobar", Optional.empty(), null)
 
         val removed_one = AwaitValue(serviceChecker.getNewOfflineNodes())
         val removed_two = AwaitValue(serviceChecker.getNewOfflineNodes())
@@ -56,7 +56,7 @@ class ServiceCheckerSpec : FunSpec({
 
     test("getNewOfflineNodes can parse a minimal service") {
         val url = server.url("/v1").toUri().toASCIIString()
-        val serviceChecker = ServiceChecker(url, "foobar-minimal", Optional.empty(), null)
+        val serviceChecker = ConsulServiceChecker(url, "foobar-minimal", Optional.empty(), null)
 
         val removed_one = AwaitValue(serviceChecker.getNewOfflineNodes())
         val removed_two = AwaitValue(serviceChecker.getNewOfflineNodes())
@@ -71,7 +71,7 @@ class ServiceCheckerSpec : FunSpec({
 
     test("getNewOfflineNodes throws when an unexpected code is enouctered") {
         val url = server.url("/v1").toUri().toASCIIString()
-        val serviceChecker = ServiceChecker(url, "foobarbaz", Optional.empty(), null)
+        val serviceChecker = ConsulServiceChecker(url, "foobarbaz", Optional.empty(), null)
 
         shouldThrow<IOException> {
             AwaitValue(serviceChecker.getNewOfflineNodes())
@@ -80,8 +80,8 @@ class ServiceCheckerSpec : FunSpec({
 
     test("getNewOfflineNodes throws an exception on not being able to parse an array") {
         val url = server.url("/v1").toUri().toASCIIString()
-        val serviceChecker = ServiceChecker(url, "foobar-obj", Optional.empty(), null)
-        val svcChecker = ServiceChecker(url, "foobar-nil", Optional.empty(), null)
+        val serviceChecker = ConsulServiceChecker(url, "foobar-obj", Optional.empty(), null)
+        val svcChecker = ConsulServiceChecker(url, "foobar-nil", Optional.empty(), null)
 
         shouldThrow<ArrayIndexOutOfBoundsException> {
             AwaitValue(svcChecker.getNewOfflineNodes())
@@ -93,7 +93,7 @@ class ServiceCheckerSpec : FunSpec({
 
     test("getNewOfflineNodes can timeout") {
         val url = server.url("/v1").toUri().toASCIIString()
-        val serviceChecker = ServiceChecker(url, "foobar-sleep", Optional.empty(), 1L)
+        val serviceChecker = ConsulServiceChecker(url, "foobar-sleep", Optional.empty(), 1L)
 
         shouldThrowAny {
             AwaitValue(serviceChecker.getNewOfflineNodes())
@@ -102,7 +102,7 @@ class ServiceCheckerSpec : FunSpec({
 
     test("it can find the difference between two lists") {
         val url = server.url("/v1").toUri().toASCIIString()
-        val serviceChecker = ServiceChecker(url, "foobar-obj", Optional.empty(), null)
+        val serviceChecker = ConsulServiceChecker(url, "foobar-obj", Optional.empty(), null)
 
         // Test two lists with just added/remove content.
         val listOne = listOf(


### PR DESCRIPTION

## Motivation

`ServiceChecker` right now is tied tightly to Consul, but for my use case, I can't use Consul.  This will remove that as a requirement, and allow me to implement a custom `ServiceChecker`.